### PR TITLE
Move pytest-astropy from run to test dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,11 +35,12 @@ requirements:
     - numpy 1.14.*  # [py>=37]
   run:
     - python
-    - pytest-astropy
     - {{ pin_compatible('numpy') }}
 
 
 test:
+  requires:
+    - pytest-astropy
   commands:
     - fits2bitmap --help
     - fitscheck --help


### PR DESCRIPTION
Hopefully this should avoid a runtime dependency on pyetst, and fix https://github.com/astropy/astropy/issues/6787