### PR TITLE
astropy 5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - packaging >=19.0
     - pyerfa >=2.0
     - pyyaml >=3.13
-    # Recommended dependencies 
+    # Recommended dependencies
     - matplotlib >=3.1,!=3.4.0
     - scipy >=1.3
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,18 +45,15 @@ requirements:
     - packaging >=19.0
     - pyerfa >=2.0
     - pyyaml >=3.13
-    # Recommended dependencies
-    - matplotlib >=3.1,!=3.4.0
-    - scipy >=1.3
+    # Recommended dependencies https://github.com/astropy/astropy/blob/d1e122dd996d885f742a33d75d38529307294baf/setup.cfg#L64
+    #- matplotlib >=3.1,!=3.4.0
+    #- scipy >=1.3
 
 test:
   requires:
     - cython
-    - h5py
-    - pandas
     - pytest-astropy >=0.9
     - pytest-xdist
-    - scikit-image
     - setuptools
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,10 +51,8 @@ requirements:
 
 test:
   requires:
-    - cython
     - pytest-astropy >=0.9
     - pytest-xdist
-    - setuptools
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - packaging >=19.0
     - pyerfa >=2.0
     - pyyaml >=3.13
-    # Recommended dependencies
+    # Recommended dependencies 
     - matplotlib >=3.1,!=3.4.0
     - scipy >=1.3
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.3.1" %}
+{% set version = "5.0" %}
 
 package:
   name: astropy
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/astropy/astropy-{{ version }}.tar.gz
-  sha256: 2d3951223b4eb7f368fcad8c8340d27374c5d8e3b635a636275acdb38f35cd51
+  sha256: 70203e151e13292586a817b4069ce1aad4643567aff38b1d191c173bc54f3927
 
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,36 +23,36 @@ build:
     - wcslint = astropy.wcs.wcslint:main
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
-  skip: true  # [py<37]
+  skip: true  # [py<38]
 
 requirements:
   build:
     - {{ compiler('c') }}
   host:
     - python 
+    - cython ==0.29.22
+    - extension-helpers
+    - jinja2 ==2.10.3
+    - numpy
     - pip
     - setuptools
-    - jinja2 ==2.10.3
-    - cython ==0.29.22
-    - setuptools_scm
+    - setuptools_scm >=6.2
     - wheel
-    - extension-helpers
-    - numpy
-    - scipy >=1.2
-    - pyyaml >=3.13
-    - matplotlib >=3.0,!=3.4.0
   run:
     - python
-    - pyerfa >=1.7.3
     - {{ pin_compatible("numpy") }}
-    - scipy >=1.2
+    - importlib-metadata
+    - packaging >=19.0
+    - pyerfa >=2.0
     - pyyaml >=3.13
-    - matplotlib >=3.0,!=3.4.0
-    - importlib-metadata  # [py==37]
+    # Recommended dependencies
+    - matplotlib >=3.1,!=3.4.0
+    - scipy >=1.3
 
 test:
   requires:
-    - pytest-astropy >=0.8
+    - pytest-astropy >=0.9
+    - pytest-xdist
     - setuptools
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,8 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python 
-    - cython ==0.29.22
+    - cython ==0.29.22  # [not arm64]
+    - cython >=0.29.22  # [linux and arm64]
     - extension-helpers
     - jinja2 ==2.10.3
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,10 +30,9 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python 
-    - cython ==0.29.22  # [not arm64]
-    - cython >=0.29.22  # [linux and arm64]
+    - cython >=0.29.22
     - extension-helpers
-    - jinja2 ==2.10.3
+    - jinja2 >=2.10.3,<3.0.0
     - numpy
     - pip
     - setuptools
@@ -52,8 +51,12 @@ requirements:
 
 test:
   requires:
+    - cython
+    - h5py
+    - pandas
     - pytest-astropy >=0.9
     - pytest-xdist
+    - scikit-image
     - setuptools
     - pip
   commands:


### PR DESCRIPTION
Update astropy to 5.0

Version change: bump version number from 4.3.1 to 5.0 (Major version bump!)
Bug Tracker: new open issues https://github.com/astropy/astropy/issues
Github releases:  https://github.com/astropy/astropy/releases
Upstream Changelog: https://github.com/astropy/astropy/blob/main/CHANGES.rst
Upstream setup.cfg:  https://github.com/astropy/astropy/blob/v5.0/setup.cfg
Upstream pyproject.toml:  https://github.com/astropy/astropy/blob/v5.0/pyproject.toml

The package astropy is mentioned inside the packages:
extension-helpers | glue-core | glue-vispy-viewers | pyerfa | pytest-astropy | pytest-astropy-header | pytest-doctestplus | pytest-filter-subpackage | pytest-openfiles | pytest-remotedata |

Actions:
1. Fix pinning for cython and jinja2
2. Update dependencies
3. Recommended dependencies were disabled, see https://github.com/astropy/astropy/blob/d1e122dd996d885f742a33d75d38529307294baf/setup.cfg#L64
```
    #- matplotlib >=3.1,!=3.4.0
    #- scipy >=1.3
```
4. Update test/requires
5. Skip `py<38`
6. Remove `setuptools `from test/requires

Result:
- all-succeeded