### PR TITLE
astropy 5.0.2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,0 @@
-numpy:
-  - 1.19  # [not (osx and arm64)]
-  - 1.19
-  - 1.19
-  - 1.21  # python 3.10

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - pkg-config  # [osx and x86_64]
   host:
     - python 
     - cython >=0.29.22
@@ -41,8 +42,7 @@ requirements:
     - wheel
   run:
     - python
-    - {{ pin_compatible("numpy") }} # [not (osx and x86_64)]
-    - numpy >=1.19  # [(osx and x86_64) and py==39]
+    - {{ pin_compatible("numpy") }}
     - importlib-metadata
     - packaging >=19.0
     - pyerfa >=2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - pkg-config  # [osx and x86_64]
+    - pkg-config
   host:
     - python 
     - cython >=0.29.22

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ build:
     - volint = astropy.io.votable.volint:main
     - wcslint = astropy.wcs.wcslint:main
   number: 0
-  # trigger: 1
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [py<38]
 
@@ -33,7 +32,8 @@ requirements:
     - python 
     - cython >=0.29.22
     - extension-helpers
-    - jinja2 >=2.10.3,<3.0.0
+    - jinja2 >=3.0.3,<3.1.0
+    - markupsafe >=2.0.1,<2.1.0
     - numpy
     - pip
     - setuptools
@@ -46,7 +46,7 @@ requirements:
     - packaging >=19.0
     - pyerfa >=2.0
     - pyyaml >=3.13
-    # Recommended dependencies https://github.com/astropy/astropy/blob/d1e122dd996d885f742a33d75d38529307294baf/setup.cfg#L64
+    # Recommended dependencies are disabled https://github.com/astropy/astropy/blob/d1e122dd996d885f742a33d75d38529307294baf/setup.cfg#L64
     #- matplotlib >=3.1,!=3.4.0
     #- scipy >=1.3
 
@@ -70,7 +70,7 @@ test:
     - astropy
 
 about:
-  home: http://www.astropy.org/
+  home: https://www.astropy.org/
   license: BSD-3-Clause
   license_file: LICENSE.rst
   license_family: BSD
@@ -79,7 +79,7 @@ about:
     The Astropy Project is a community effort to develop a single package for
     Astronomy in Python. It contains core functionality and common tools
     needed for performing astronomy and astrophysics research with Python.
-  doc_url: http://docs.astropy.org/en/stable/
+  doc_url: https://docs.astropy.org/en/stable/
   dev_url: https://github.com/astropy/astropy
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.0" %}
+{% set version = "5.0.2" %}
 
 package:
   name: astropy
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/astropy/astropy-{{ version }}.tar.gz
-  sha256: 70203e151e13292586a817b4069ce1aad4643567aff38b1d191c173bc54f3927
+  sha256: 449f0ba5e7292457eed37550b047444751a606e7b8a34f93b1c28d0bb63e7f40
 
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,8 @@ requirements:
     - python 
     - cython >=0.29.22
     - extension-helpers
-    - jinja2 >=3.0.3,<3.1.0
-    - markupsafe >=2.0.1,<2.1.0
+    - jinja2 >=3.0.3
+    - markupsafe >=2.0.1
     - numpy
     - pip
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,8 @@ requirements:
     - wheel
   run:
     - python
-    - {{ pin_compatible("numpy") }}
+    - {{ pin_compatible("numpy") }} # [not (osx and x86_64)]
+    - numpy >=1.19  # [(osx and x86_64) and py==39]
     - importlib-metadata
     - packaging >=19.0
     - pyerfa >=2.0


### PR DESCRIPTION
Update astropy to 5.0.2

Version change: bump version number from 5.0 to 5.0.2
Bug Tracker: new open issues https://github.com/astropy/astropy/issues
Github releases:  https://github.com/astropy/astropy/releases
Upstream Changelog: https://github.com/astropy/astropy/blob/main/CHANGES.rst
Upstream setup.cfg:  https://github.com/astropy/astropy/blob/v5.0.2/setup.cfg
Upstream pyproject.toml:  https://github.com/astropy/astropy/blob/v5.0.2/pyproject.toml

The package astropy is mentioned inside the packages:
extension-helpers | glue-core | glue-vispy-viewers | pyerfa | pytest-astropy | pytest-astropy-header | pytest-doctestplus | pytest-filter-subpackage | pytest-openfiles | pytest-remotedata |

Actions:
1. Update pinnings for jinja2 and markupsafe
2. Fix home and doc urls with HTTPS