### PR TITLE
astropy 5.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.0.2" %}
+{% set version = "5.0.3" %}
 
 package:
   name: astropy
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/astropy/astropy-{{ version }}.tar.gz
-  sha256: 449f0ba5e7292457eed37550b047444751a606e7b8a34f93b1c28d0bb63e7f40
+  sha256: 1b164ec55eb71c7f0f8a5f3354339c5a42d61298356b214e4fb9ff256a868147
 
 
 build:


### PR DESCRIPTION
Update astropy to 5.0.3

Version change: bump version number from 5.0.2 to 5.0.3
Bug Tracker: new open issues https://github.com/astropy/astropy/issues
Upstream Changelog: https://github.com/astropy/astropy/blob/main/CHANGES.rst
Upstream setup.cfg: https://github.com/astropy/astropy/blob/v5.0.3/setup.cfg
Upstream pyproject.toml: https://github.com/astropy/astropy/blob/v5.0.3/pyproject.toml

No changes