### PR TITLE
astropy 5.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.0.3" %}
+{% set version = "5.0.4" %}
 
 package:
   name: astropy
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/astropy/astropy-{{ version }}.tar.gz
-  sha256: 1b164ec55eb71c7f0f8a5f3354339c5a42d61298356b214e4fb9ff256a868147
+  sha256: 001184f1a9c3f526a363883ce28efb9cbf076df3d151ca3e131509a248f0dfb9
 
 
 build:
@@ -43,7 +43,6 @@ requirements:
   run:
     - python
     - {{ pin_compatible("numpy") }}
-    - importlib-metadata
     - packaging >=19.0
     - pyerfa >=2.0
     - pyyaml >=3.13


### PR DESCRIPTION
Update astropy to 5.0.4

Version change: bump version number from 5.0.3 to 5.0.4
Bug Tracker: new open issues https://github.com/astropy/astropy/issues
Upstream Changelog: https://github.com/astropy/astropy/blob/main/CHANGES.rst
Upstream setup.cfg: https://github.com/astropy/astropy/blob/v5.0.4/setup.cfg
Upstream pyproject.toml: https://github.com/astropy/astropy/blob/v5.0.4/pyproject.toml

Actions:
1. Remove `importlib-metadata` from `run` because python 3.7 support was dropped on Aug 26, 2021, see https://github.com/astropy/astropy/commit/a0e1646c3cb242cd4b155a93aa4b330968024775 