### PR TITLE
astropy 5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,19 @@
-{% set version = "5.0.4" %}
+{% set name = "astropy" %}
+{% set version = "5.1" %}
 
 package:
-  name: astropy
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/a/astropy/astropy-{{ version }}.tar.gz
-  sha256: 001184f1a9c3f526a363883ce28efb9cbf076df3d151ca3e131509a248f0dfb9
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1db1b2c7eddfc773ca66fa33bd07b25d5b9c3b5eee2b934e0ca277fa5b1b7b7e
 
 
 build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<38]
   detect_binary_files_with_prefix: false
   entry_points:
     - fits2bitmap = astropy.visualization.scripts.fits2bitmap:main
@@ -21,9 +25,6 @@ build:
     - showtable = astropy.table.scripts.showtable:main
     - volint = astropy.io.votable.volint:main
     - wcslint = astropy.wcs.wcslint:main
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  skip: true  # [py<38]
 
 requirements:
   build:
@@ -31,10 +32,8 @@ requirements:
     - pkg-config
   host:
     - python 
-    - cython >=0.29.22
+    - cython >=0.29.30
     - extension-helpers
-    - jinja2 >=3.0.3
-    - markupsafe >=2.0.1
     - numpy
     - pip
     - setuptools
@@ -47,12 +46,12 @@ requirements:
     - pyerfa >=2.0
     - pyyaml >=3.13
     # Recommended dependencies are disabled https://github.com/astropy/astropy/blob/d1e122dd996d885f742a33d75d38529307294baf/setup.cfg#L64
-    #- matplotlib >=3.1,!=3.4.0
+    #- matplotlib >=3.1,!=3.4.0,!=3.5.2
     #- scipy >=1.3
 
 test:
   requires:
-    - pytest-astropy >=0.9
+    - pytest-astropy >=0.10
     - pytest-xdist
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [py<38]
-  detect_binary_files_with_prefix: false
   entry_points:
     - fits2bitmap = astropy.visualization.scripts.fits2bitmap:main
     - fitscheck = astropy.io.fits.scripts.fitscheck:main

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,9 +1,11 @@
+import platform
+
 # import astropy._compiler
-import astropy.cosmology.scalar_inv_efuncs
+import astropy.cosmology.flrw.scalar_inv_efuncs
 import astropy.io.ascii.cparser
 import astropy.io.fits.compression
 import astropy.io.votable.tablewriter
-import astropy.modeling._projections
+import astropy.modeling.projections
 import astropy.timeseries.periodograms.lombscargle.implementations.cython_impl
 import astropy.table._column_mixins
 import astropy.table._np_utils
@@ -22,6 +24,11 @@ from astropy import test
 # They take more than two hours to run on some platforms!
 # test(package='io.ascii')
 
-test(package='time')
-test(package='wcs')
-test(package='convolution')
+if ((platform.machine() == 'aarch64') and
+    (platform.python_implementation().lower() != 'cpython')):
+    print('WARNING: Skipping tests on aarch64/PyPy because they take too long')
+
+else:
+    test(package='time')
+    test(package='wcs')
+    test(package='convolution')


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/astropy/astropy/issues
License: https://github.com/astropy/astropy/blob/main/LICENSE.rst
Changelog: https://github.com/astropy/astropy/blob/main/CHANGES.rst
Requirements:
- https://github.com/astropy/astropy/blob/v5.1/setup.cfg
- https://github.com/astropy/astropy/blob/v5.1/pyproject.toml

Actions:
1. Remove `jinja2` & `markupsafe` from `host` because jinja2 is no longer needed, see: 
- https://github.com/astropy/astropy/commit/87e73fababde2e2576e1255de0ca45f213079683 
- https://github.com/astropy/astropy/pull/12558. 
- I grep the source code for v5.1 and `markupsafe` isn't mentioned in at all
3. Update `cython` pinning
4. Fix `run_test.py`
5. Enable checking for binary prefix, see https://github.com/conda-forge/astropy-feedstock/commit/978b1e11ba42309c49610186d9b33c725d731af6