### PR TITLE
[PKG-2811] astropy 5.3.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "astropy" %}
-{% set version = "5.1" %}
+{% set version = "5.3.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1db1b2c7eddfc773ca66fa33bd07b25d5b9c3b5eee2b934e0ca277fa5b1b7b7e
+  sha256: d490f7e2faac2ccc01c9244202d629154259af8a979104ced89dc4ace4e6f1d8
 
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  skip: true  # [py<38]
+  skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - fits2bitmap = astropy.visualization.scripts.fits2bitmap:main
     - fitscheck = astropy.io.fits.scripts.fitscheck:main
@@ -30,13 +30,13 @@ requirements:
     - {{ compiler('c') }}
     - pkg-config
   host:
-    - python 
-    - cython >=0.29.30
+    - python
+    - cython 0.29
     - extension-helpers
-    - numpy
+    - numpy {{ numpy }}
     - pip
     - setuptools
-    - setuptools_scm >=6.2
+    - setuptools_scm
     - wheel
   run:
     - python
@@ -45,11 +45,13 @@ requirements:
     - pyerfa >=2.0
     - pyyaml >=3.13
     # Recommended dependencies are disabled https://github.com/astropy/astropy/blob/d1e122dd996d885f742a33d75d38529307294baf/setup.cfg#L64
-    #- matplotlib >=3.1,!=3.4.0,!=3.5.2
-    #- scipy >=1.3
+    #- matplotlib >=3.3,!=3.4.0,!=3.5.2
+    #- scipy >=1.5
 
 test:
+  # to satisfy the anaconda-linter python imports moved into run_test.py 
   requires:
+    - pytest >=7.0,<8
     - pytest-astropy >=0.10
     - pytest-xdist
     - pip
@@ -64,8 +66,7 @@ test:
     - volint --help
     - wcslint --help
     - showtable --help
-  imports:
-    - astropy
+
 
 about:
   home: https://www.astropy.org/

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -3,14 +3,12 @@ import platform
 # import astropy._compiler
 import astropy.cosmology.flrw.scalar_inv_efuncs
 import astropy.io.ascii.cparser
-import astropy.io.fits.compression
 import astropy.io.votable.tablewriter
 import astropy.modeling.projections
 import astropy.timeseries.periodograms.lombscargle.implementations.cython_impl
 import astropy.table._column_mixins
 import astropy.table._np_utils
-import astropy.utils._compiler
-import astropy.utils.xml._iterparser
+import astropy.utils.xml.iterparser
 import astropy.wcs._wcs
 
 # We run a subset of the tests which are the most likely to have


### PR DESCRIPTION
License: https://github.com/astropy/astropy/blob/main/LICENSE.rst
Changelog: https://github.com/astropy/astropy/blob/main/CHANGES.rst
Requirements:
- https://github.com/astropy/astropy/blob/v5.3.4/setup.cfg
- https://github.com/astropy/astropy/blob/v5.3.4/pyproject.toml

Actions:
1. Skip `py<39`
2. Add `--no-deps --no-build-isolation` to `script`
3. Fix `cython` pinning and remove it for `setuptools_scm`
4. Remove `test/imports` as they were placed in `run_test.py`
5. Add `pytest >=7,<8` to `test/requires`
6. Remove obsolete imports from `run_test.py`