### PR TITLE
astropy 7.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - /prefect/fs/astropy-iers-data-feedstock/pr3/3897050

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
 channels:
-  - https://staging.continuum.io/prefect/fs/astropy-iers-data-feedstock/pr3/3897050
+  - https://staging.continuum.io/prefect/fs/astropy-iers-data-feedstock/pr3/fa63d21

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,4 +5,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/astropy-iers-data-feedstock/pr3/fa63d21
   - https://staging.continuum.io/prefect/fs/pyerfa-feedstock/pr5/f93eda3
   - https://staging.continuum.io/prefect/fs/pytest-astropy-feedstock/pr5/c80b4ef
-  -   - https://staging.continuum.io/prefect/fs/pytest-arraydiff-feedstock/pr3/5462b14
+  - https://staging.continuum.io/prefect/fs/pytest-arraydiff-feedstock/pr3/5462b14

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,5 +4,9 @@ build_env_vars:
 channels:
   - https://staging.continuum.io/prefect/fs/astropy-iers-data-feedstock/pr3/fa63d21
   - https://staging.continuum.io/prefect/fs/pyerfa-feedstock/pr5/f93eda3
-  - https://staging.continuum.io/prefect/fs/pytest-astropy-feedstock/pr5/c80b4ef
-  - https://staging.continuum.io/prefect/fs/pytest-arraydiff-feedstock/pr3/5462b14
+  - https://staging.continuum.io/prefect/fs/pytest-astropy-feedstock/pr5/cea5642
+  - https://staging.continuum.io/prefect/fs/pytest-arraydiff-feedstock/pr3/cd842ea
+  - https://staging.continuum.io/prefect/fs/pytest-astropy-header-feedstock/pr3/0abff91
+  - https://staging.continuum.io/prefect/fs/pytest-doctestplus-feedstock/pr8/695fc0b
+  - https://staging.continuum.io/prefect/fs/pytest-filter-subpackage-feedstock/pr1/85e8265
+  - https://staging.continuum.io/prefect/fs/pytest-remotedata-feedstock/pr2/a56c162

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,5 @@ build_env_vars:
 channels:
   - https://staging.continuum.io/prefect/fs/astropy-iers-data-feedstock/pr3/fa63d21
   - https://staging.continuum.io/prefect/fs/pyerfa-feedstock/pr5/f93eda3
+  - https://staging.continuum.io/prefect/fs/pytest-astropy-feedstock/pr5/c80b4ef
+  -   - https://staging.continuum.io/prefect/fs/pytest-arraydiff-feedstock/pr3/5462b14

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,4 @@ build_env_vars:
 
 channels:
   - https://staging.continuum.io/prefect/fs/astropy-iers-data-feedstock/pr3/fa63d21
+  - https://staging.continuum.io/prefect/fs/pyerfa-feedstock/pr5/f93eda3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - /prefect/fs/astropy-iers-data-feedstock/pr3/3897050
+  - https://staging.continuum.io/prefect/fs/astropy-iers-data-feedstock/pr3/3897050

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,12 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/astropy-iers-data-feedstock/pr3/fa63d21
-  - https://staging.continuum.io/prefect/fs/pyerfa-feedstock/pr5/f93eda3
-  - https://staging.continuum.io/prefect/fs/pytest-astropy-feedstock/pr5/cea5642
-  - https://staging.continuum.io/prefect/fs/pytest-arraydiff-feedstock/pr3/cd842ea
-  - https://staging.continuum.io/prefect/fs/pytest-astropy-header-feedstock/pr3/0abff91
-  - https://staging.continuum.io/prefect/fs/pytest-doctestplus-feedstock/pr8/695fc0b
-  - https://staging.continuum.io/prefect/fs/pytest-filter-subpackage-feedstock/pr1/85e8265
-  - https://staging.continuum.io/prefect/fs/pytest-remotedata-feedstock/pr2/a56c162

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,9 +73,8 @@ test:
   source_files:
     - astropy/tests/
   requires:
-    - pytest >=7.3.0
-    - pytest-astropy >=0.10
-    - pytest-xdist >=2.5.0
+    - pytest
+    - pytest-astropy
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.24
+    - numpy >=1.24  # from dask(array)
     - pyerfa >=2.0.1.1
     - astropy-iers-data >=0.2024.10.28.0.34.7
     - pyyaml >=6.0.0
@@ -64,7 +64,7 @@ requirements:
     - asdf-astropy >=0.3
     - bottleneck >=1.3.3
     - fsspec >=2023.4.0
-    - aiohttp !=4.0.0a0,!=4.0.0a1  # from fsspec[http]
+    - aiohttp !=4.0.0a0,!=4.0.0a1  # from fsspec(http)
     - s3fs >=2023.4.0
     - pandas-stubs >=2.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.24  # from dask(array)
+    - numpy >=1.23.2
     - pyerfa >=2.0.1.1
     - astropy-iers-data >=0.2024.10.28.0.34.7
     - pyyaml >=6.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.24  # from dask[array]
+    - numpy >=1.24
     - pyerfa >=2.0.1.1
     - astropy-iers-data >=0.2024.10.28.0.34.7
     - pyyaml >=6.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.23.2
+    - numpy >=1.24  # from dask[array]
     - pyerfa >=2.0.1.1
     - astropy-iers-data >=0.2024.10.28.0.34.7
     - pyyaml >=6.0.0
@@ -48,17 +48,30 @@ requirements:
     - matplotlib-base >=3.6.0
     - scipy >=1.9.2
   run_constrained:
+    - certifi >=2022.6.15.1
+    - dask >=2022.5.1
+    - h5py >=3.8.0
     - pyarrow >=10.0.1
+    - beautifulsoup4 >=4.9.3
+    - html5lib >=1.1
+    - bleach >=3.2.1
+    - pandas >=2.0
+    - sortedcontainers >=1.5.7
+    - pytz >=2016.10
+    - jplephem >=2.6
+    - mpmath >=1.2.1
+    - asdf >=2.8.3
     - asdf-astropy >=0.3
-    - ipython >=8.0.0
-    - pytest >=7.0
+    - bottleneck >=1.3.3
     - fsspec >=2023.4.0
-    # Requests needed for fsspec[http]
-    - requests
+    - aiohttp !=4.0.0a0,!=4.0.0a1  # from fsspec[http]
     - s3fs >=2023.4.0
+    - pandas-stubs >=2.0
 
 test:
   # to satisfy the anaconda-linter python imports moved into run_test.py
+  source_files:
+    - astropy/tests/
   requires:
     - pytest >=7.3.0
     - pytest-astropy >=0.10
@@ -75,6 +88,7 @@ test:
     - volint --help
     - wcslint --help
     - showtable --help
+    - pytest astropy/tests/ -vv -k "not test_logger"
 
 about:
   home: https://www.astropy.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,8 +73,9 @@ test:
   source_files:
     - astropy/tests/
   requires:
-    - pytest
-    - pytest-astropy
+    - pytest >=7.3.0
+    - pytest-astropy >=0.10
+    - pytest-xdist >=2.5.0
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9ac834cdedc1f6b5ce6f941f7bfbbfc58fca861eb172bcf72dd90aff8f750970
+  sha256: e92d7c9fee86eb3df8714e5dd41bbf9f163d343e1a183d95bf6bd09e4313c940
 
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "astropy" %}
-{% set version = "6.1.3" %}
+{% set version = "7.0.0" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,18 +40,18 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.23
+    - numpy >=1.23.2
     - pyerfa >=2.0.1.1
-    - astropy-iers-data >=0.2024.7.29.0.32.7
-    - pyyaml >=3.13
-    - packaging >=19.0
-    - matplotlib-base >=3.3,!=3.4.0,!=3.5.2
-    - scipy >=1.8
+    - astropy-iers-data >=0.2024.10.28.0.34.7
+    - pyyaml >=6.0.0
+    - packaging >=22.0.0
+    - matplotlib-base >=3.6.0
+    - scipy >=1.9.2
   run_constrained:
     - typing_extensions >=4.0.0
     - pyarrow >=7.0.0
     - asdf-astropy >=0.3
-    - ipython >=4.2
+    - ipython >=8.0.0
     - pytest >=7.0
     - fsspec >=2023.4.0
     # Requests needed for fsspec[http]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<310]
+  skip: true  # [py<311]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - fits2bitmap = astropy.visualization.scripts.fits2bitmap:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,8 +48,7 @@ requirements:
     - matplotlib-base >=3.6.0
     - scipy >=1.9.2
   run_constrained:
-    - typing_extensions >=4.0.0
-    - pyarrow >=7.0.0
+    - pyarrow >=10.0.1
     - asdf-astropy >=0.3
     - ipython >=8.0.0
     - pytest >=7.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,9 +60,9 @@ requirements:
 test:
   # to satisfy the anaconda-linter python imports moved into run_test.py
   requires:
-    - pytest >=7.0,<8
+    - pytest >=7.3.0
     - pytest-astropy >=0.10
-    - pytest-xdist
+    - pytest-xdist >=2.5.0
     - pip
   commands:
     - pip check


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6622](https://anaconda.atlassian.net/browse/PKG-6622)
- [Upstream repository](https://github.com/astropy/astropy/tree/v7.0.0)
- [Upstream changelog/diff](https://github.com/astropy/astropy/blob/v7.0.0/CHANGES.rst)


### Explanation of changes:

- Update version and sha
- Update python version skip
- Update dependencies
- Build for python 3.13
- Add and run upstream tests


[PKG-6622]: https://anaconda.atlassian.net/browse/PKG-6622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ